### PR TITLE
Expand errors, add causes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - **BREAKING**: Require node 14.x.
 - **BREAKING**: `setAutoRotationChecker` takes the named parameter `method`
   now instead of being unnamed.
+- **BREAKING**: Improve errors and error causes when getting the current
+  tokenizer.
+- Add logging of various tokenizer creation / rotation errors.
 
 ## 6.0.0 - 2022-03-17
 

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -12,8 +12,7 @@ const {KeystoreAgent, KmsClient} = require('@digitalbazaar/webkms-client');
 const {util: {BedrockError}} = bedrock;
 
 bedrock.events.on('bedrock.init', () => {
-  if(!(bedrock.config && bedrock.config.tokenizer &&
-    bedrock.config.tokenizer.kms && bedrock.config.tokenizer.kms.baseUrl)) {
+  if(!bedrock.config.tokenizer?.kms?.baseUrl) {
     throw new TypeError(
       '"bedrock.config.tokenizer.kms.baseUrl" config value is required.');
   }

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -25,11 +25,13 @@ bedrock.events.on('bedrock.init', () => {
  * @param {string} options.controller - Keystore controller DID.
  * @param {string} [options.kmsModule] - KMS module type.
  * @param {string} [options.meterId] - Meter ID.
- * @param {string} [options.invocationSigner]
- * @param {string} [options.referenceId]
- * @param {boolean} [options.applyIpAllowList=true]
+ * @param {string} [options.invocationSigner] - The invocation signer.
+ * @param {string} [options.referenceId] - An optional reference ID for the
+ *   keystore.
+ * @param {boolean} [options.applyIpAllowList=true] - Indicates whether the
+ *   configured IP allow list should be applied to the keystore or not.
  *
- * @return {Promise<object>} Resolves to the configuration for the newly
+ * @returns {Promise<object>} Resolves to the configuration for the newly
  *   created keystore.
  */
 export async function createKeystore({
@@ -73,9 +75,10 @@ export async function createKeystore({
     });
   } catch(cause) {
     const error = new BedrockError(
-      'Error creating keystore for tokenizer.', 'UnknownError',
+      'Error creating keystore for tokenizer.',
+      'OperationError',
       {httpStatusCode: 500, public: true}, cause);
-    logger.error(error);
+    logger.error(error.message, {error});
     throw error;
   }
   return result;

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -5,6 +5,7 @@ import * as bedrock from '@bedrock/core';
 import * as brHttpsAgent from '@bedrock/https-agent';
 import {createRequire} from 'module';
 import {getAppIdentity} from '@bedrock/app-identity';
+import {logger} from './logger.js';
 const require = createRequire(import.meta.url);
 const {KeystoreAgent, KmsClient} = require('@digitalbazaar/webkms-client');
 
@@ -73,9 +74,11 @@ export async function createKeystore({
       httpsAgent
     });
   } catch(cause) {
-    throw new BedrockError(
+    const error = new BedrockError(
       'Error creating keystore for tokenizer.', 'UnknownError',
       {httpStatusCode: 400, public: true}, cause);
+    logger.error(error);
+    throw error;
   }
   return result;
 }

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -65,9 +65,8 @@ export async function createKeystore({
     keystoreConfig.referenceId = referenceId;
   }
   const {httpsAgent} = brHttpsAgent;
-  let result;
   try {
-    result = await KmsClient.createKeystore({
+    return await KmsClient.createKeystore({
       url: `${bedrock.config.tokenizer.kms.baseUrl}/keystores`,
       config: keystoreConfig,
       invocationSigner,
@@ -81,7 +80,6 @@ export async function createKeystore({
     logger.error(error.message, {error});
     throw error;
   }
-  return result;
 }
 
 export async function getKeystore({id, capability, invocationSigner} = {}) {

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -10,6 +10,14 @@ const {KeystoreAgent, KmsClient} = require('@digitalbazaar/webkms-client');
 
 const {util: {BedrockError}} = bedrock;
 
+bedrock.events.on('bedrock.init', async () => {
+  if(!(bedrock.config && bedrock.config.tokenizer &&
+    bedrock.config.tokenizer.kms && bedrock.config.tokenizer.kms.baseUrl)) {
+    throw new TypeError(
+      'bedrock.config.tokenizer.kms.baseUrl config value is required.');
+  }
+});
+
 /**
  * Creates a new WebKMS keystore for tokenizer use.
  * Requires bedrock.config.tokenizer.kms.baseUrl to be set.
@@ -29,11 +37,6 @@ export async function createKeystore({
   controller, kmsModule, meterId, invocationSigner, referenceId,
   applyIpAllowList = true
 } = {}) {
-  if(!(bedrock.config && bedrock.config.tokenizer &&
-    bedrock.config.tokenizer.kms && bedrock.config.tokenizer.kms.baseUrl)) {
-    throw new TypeError(
-      'bedrock.config.tokenizer.kms.baseUrl config value is required.');
-  }
   // use default KMS module if not provided
   if(!kmsModule) {
     kmsModule = bedrock.config.tokenizer.kms.defaultKmsModule;
@@ -70,8 +73,9 @@ export async function createKeystore({
       httpsAgent
     });
   } catch(cause) {
-    throw new BedrockError('Error creating keystore for tokenizer.',
-      'WebKMSClientError', null, cause);
+    throw new BedrockError(
+      'Error creating keystore for tokenizer.', 'UnknownError',
+      {httpStatusCode: 400, public: true}, cause);
   }
   return result;
 }

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -8,10 +8,32 @@ import {getAppIdentity} from '@bedrock/app-identity';
 const require = createRequire(import.meta.url);
 const {KeystoreAgent, KmsClient} = require('@digitalbazaar/webkms-client');
 
+const {util: {BedrockError}} = bedrock;
+
+/**
+ * Creates a new WebKMS keystore for tokenizer use.
+ * Requires bedrock.config.tokenizer.kms.baseUrl to be set.
+ *
+ * @param {object} options - Options hashmap.
+ * @param {string} options.controller - Keystore controller DID.
+ * @param {string} [options.kmsModule] - KMS module type.
+ * @param {string} [options.meterId] - Meter ID.
+ * @param {string} [options.invocationSigner]
+ * @param {string} [options.referenceId]
+ * @param {boolean} [options.applyIpAllowList=true]
+ *
+ * @return {Promise<object>} Resolves to the configuration for the newly
+ *   created keystore.
+ */
 export async function createKeystore({
   controller, kmsModule, meterId, invocationSigner, referenceId,
   applyIpAllowList = true
 } = {}) {
+  if(!(bedrock.config && bedrock.config.tokenizer &&
+    bedrock.config.tokenizer.kms && bedrock.config.tokenizer.kms.baseUrl)) {
+    throw new TypeError(
+      'bedrock.config.tokenizer.kms.baseUrl config value is required.');
+  }
   // use default KMS module if not provided
   if(!kmsModule) {
     kmsModule = bedrock.config.tokenizer.kms.defaultKmsModule;
@@ -39,12 +61,19 @@ export async function createKeystore({
     keystoreConfig.referenceId = referenceId;
   }
   const {httpsAgent} = brHttpsAgent;
-  return KmsClient.createKeystore({
-    url: `${bedrock.config.tokenizer.kms.baseUrl}/keystores`,
-    config: keystoreConfig,
-    invocationSigner,
-    httpsAgent
-  });
+  let result;
+  try {
+    result = await KmsClient.createKeystore({
+      url: `${bedrock.config.tokenizer.kms.baseUrl}/keystores`,
+      config: keystoreConfig,
+      invocationSigner,
+      httpsAgent
+    });
+  } catch(cause) {
+    throw new BedrockError('Error creating keystore for tokenizer.',
+      'WebKMSClientError', null, cause);
+  }
+  return result;
 }
 
 export async function getKeystore({id, capability, invocationSigner} = {}) {

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -21,7 +21,6 @@ bedrock.events.on('bedrock.init', () => {
 
 /**
  * Creates a new WebKMS keystore for tokenizer use.
- * Requires bedrock.config.tokenizer.kms.baseUrl to be set.
  *
  * @param {object} options - Options hashmap.
  * @param {string} options.controller - Keystore controller DID.

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -11,11 +11,11 @@ const {KeystoreAgent, KmsClient} = require('@digitalbazaar/webkms-client');
 
 const {util: {BedrockError}} = bedrock;
 
-bedrock.events.on('bedrock.init', async () => {
+bedrock.events.on('bedrock.init', () => {
   if(!(bedrock.config && bedrock.config.tokenizer &&
     bedrock.config.tokenizer.kms && bedrock.config.tokenizer.kms.baseUrl)) {
     throw new TypeError(
-      'bedrock.config.tokenizer.kms.baseUrl config value is required.');
+      '"bedrock.config.tokenizer.kms.baseUrl" config value is required.');
   }
 });
 
@@ -76,7 +76,7 @@ export async function createKeystore({
   } catch(cause) {
     const error = new BedrockError(
       'Error creating keystore for tokenizer.', 'UnknownError',
-      {httpStatusCode: 400, public: true}, cause);
+      {httpStatusCode: 500, public: true}, cause);
     logger.error(error);
     throw error;
   }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as bedrock from 'bedrock';
+
+export const logger = bedrock.loggers.get('app').child('bedrock-tokenizer');

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,6 @@
 /*!
- * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2021-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import * as bedrock from 'bedrock';
+import {loggers} from '@bedrock/core';
 
-export const logger = bedrock.loggers.get('app').child('bedrock-tokenizer');
+export const logger = loggers.get('app').child('bedrock-tokenizer');

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -67,7 +67,7 @@ export async function get({id, explain = false} = {}) {
   if(!record) {
     const error = new BedrockError(
       'Tokenizer not found.',
-      'InvalidStateError', {httpStatusCode: 503, public: true});
+      'NotFoundError', {httpStatusCode: 404, public: true});
     logger.error(error);
     throw error;
   }

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -308,7 +308,7 @@ export async function _createTokenizer() {
     await _markTokenizerAsCurrent();
   } catch(cause) {
     const error = new BedrockError(
-      'Error creating keystore for tokenizer.', 'OperationError',
+      'Error creating tokenizer.', 'OperationError',
       {httpStatusCode: 500, public: true}, cause);
     logger.error(error.message, {error});
     throw error;

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -258,44 +258,53 @@ async function _tokenizerFromRecord({record}) {
 }
 
 export async function _createTokenizer() {
-  // 1. Generate a random secret.
-  const secret = await randomBytesAsync(32);
-  // 2. Generate capability agent from handle and secret.
-  const handle = 'primary';
-  const capabilityAgent = await CapabilityAgent.fromSecret({handle, secret});
-  // 3. Store the tokenizer record with pending state.
-  const collection = database.collections['tokenizer-tokenizer'];
-  const now = Date.now();
-  const meta = {created: now, updated: now};
-  const tokenizer = {
-    id: capabilityAgent.id,
-    secret: base64url.encode(secret),
-    state: 'pending'
-  };
-  const record = {
-    meta,
-    tokenizer
-  };
   try {
-    await collection.insertOne(record);
-  } catch(e) {
-    if(!database.isDuplicateError(e)) {
-      throw e;
+    // 1. Generate a random secret.
+    const secret = await randomBytesAsync(32);
+    // 2. Generate capability agent from handle and secret.
+    const handle = 'primary';
+    const capabilityAgent = await CapabilityAgent.fromSecret({handle, secret});
+    // 3. Store the tokenizer record with pending state.
+    const collection = database.collections['tokenizer-tokenizer'];
+    const now = Date.now();
+    const meta = {created: now, updated: now};
+    const tokenizer = {
+      id: capabilityAgent.id,
+      secret: base64url.encode(secret),
+      state: 'pending'
+    };
+    const record = {
+      meta,
+      tokenizer
+    };
+    try {
+      await collection.insertOne(record);
+    } catch(e) {
+      if(!database.isDuplicateError(e)) {
+        throw e;
+      }
+      throw new BedrockError(
+        'Duplicate tokenizer.',
+        'DuplicateError', {
+          public: true,
+          httpStatusCode: 409
+        }, e);
     }
-    throw new BedrockError(
-      'Duplicate tokenizer.',
-      'DuplicateError', {
-        public: true,
-        httpStatusCode: 409
-      }, e);
-  }
 
-  // 4. Create a keystore and HMAC key for the tokenizer.
-  let keystore;
-  try {
-    keystore = await kms.createKeystore({
+    // 4. Create a keystore and HMAC key for the tokenizer.
+    const keystore = await kms.createKeystore({
       controller: capabilityAgent.id, referenceId: 'primary'
     });
+
+    const keystoreAgent = kms.getKeystoreAgent(
+      {capabilityAgent, keystoreId: keystore.id});
+    const key = await keystoreAgent.generateKey({type: 'hmac'});
+
+    // 5. Ready tokenizer for use by adding keystore and HMAC key to its record.
+    await _readyTokenizer({tokenizer, keystore, key});
+
+    // mark any ready tokenizer as current
+    await _markTokenizerAsCurrent();
   } catch(cause) {
     const error = new BedrockError(
       'Error creating keystore for tokenizer.', 'UnknownError',
@@ -303,16 +312,6 @@ export async function _createTokenizer() {
     logger.error(error);
     throw error;
   }
-
-  const keystoreAgent = kms.getKeystoreAgent(
-    {capabilityAgent, keystoreId: keystore.id});
-  const key = await keystoreAgent.generateKey({type: 'hmac'});
-
-  // 5. Ready tokenizer for use by adding keystore and HMAC key to its record.
-  await _readyTokenizer({tokenizer, keystore, key});
-
-  // mark any ready tokenizer as current
-  await _markTokenizerAsCurrent();
 }
 
 export async function _readyTokenizer({

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -131,8 +131,7 @@ export async function deprecateCurrent({explain = false} = {}) {
   }
 
   try {
-    const result = await collection.updateOne(
-      query, {$set, $unset}, database.writeOptions);
+    const result = await collection.updateOne(query, {$set, $unset});
     // return `true` if a tokenizer was marked as `deprecated`
     return result.result.n === 0;
   } catch(cause) {

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -68,7 +68,7 @@ export async function get({id, explain = false} = {}) {
     const error = new BedrockError(
       'Tokenizer not found.',
       'NotFoundError', {httpStatusCode: 404, public: true});
-    logger.error(error);
+    logger.error(error.message, {error});
     throw error;
   }
 

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -82,24 +82,24 @@ export async function get({id, explain = false} = {}) {
  * @return {Promise<{hmac: Hmac, id: string}>}
  */
 export async function getCurrent() {
-  // 1. Check to see if rotation is required...
-  if(AUTO_ROTATION_CHECKER && _isRotationCheckRequired()) {
-    // 1.1. Rotate tokenizer if necessary.
-    const shouldRotate = await AUTO_ROTATION_CHECKER();
-    if(shouldRotate) {
-      await deprecateCurrent();
-      // clear cached current tokenizer; note: the cached value *may* not match
-      // the one that was just marked deprecated due to multiple concurrent
-      // requests modifying the cached value, but this should not create
-      // invalid state, rather, it just generates an extra database read
-      CACHED_TOKENIZER = null;
-    }
-  }
-
-  // 2. Get the current tokenizer.
-  let tokenizer;
   try {
-    tokenizer = await _getCurrentTokenizer();
+    // 1. Check to see if rotation is required...
+    if(AUTO_ROTATION_CHECKER && _isRotationCheckRequired()) {
+      // 1.1. Rotate tokenizer if necessary.
+      const shouldRotate = await AUTO_ROTATION_CHECKER();
+      if(shouldRotate) {
+        await deprecateCurrent();
+        // clear cached current tokenizer; note: the cached value *may* not
+        // match the one that was just marked deprecated due to multiple
+        // concurrent requests modifying the cached value, but this should
+        // not create invalid state, rather, it just generates an extra
+        // database read
+        CACHED_TOKENIZER = null;
+      }
+    }
+
+    // 2. Get the current tokenizer.
+    return await _getCurrentTokenizer();
   } catch(cause) {
     const error = new BedrockError(
       'Could not get current tokenizer.', 'InvalidStateError',
@@ -107,7 +107,6 @@ export async function getCurrent() {
     logger.error(error);
     throw error;
   }
-  return tokenizer;
 }
 
 export async function deprecateCurrent({explain = false} = {}) {
@@ -229,7 +228,7 @@ export async function _readCurrentTokenizerRecord({explain = false} = {}) {
   if(!record) {
     const error = new BedrockError(
       'Current tokenizer not found.',
-      'InvalidStateError', {httpStatusCode: 503, public: true});
+      'NotFoundError', {httpStatusCode: 404, public: true});
     logger.error(error);
     throw error;
   }

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -76,6 +76,12 @@ export async function get({id, explain = false} = {}) {
   return _tokenizerFromRecord({record});
 }
 
+/**
+ * Returns the current tokenizer object (rotating it if required).
+ *
+ * @typedef Hmac
+ * @return {Promise<{hmac: Hmac, id: string}>}
+ */
 export async function getCurrent() {
   // 1. Check to see if rotation is required...
   if(AUTO_ROTATION_CHECKER && _isRotationCheckRequired()) {
@@ -92,7 +98,14 @@ export async function getCurrent() {
   }
 
   // 2. Get the current tokenizer.
-  return _getCurrentTokenizer();
+  let tokenizer;
+  try {
+    tokenizer = await _getCurrentTokenizer();
+  } catch(cause) {
+    throw new BedrockError('Could not get current tokenizer.', 'NotFoundError',
+      {httpStatusCode: 404}, cause);
+  }
+  return tokenizer;
 }
 
 export async function deprecateCurrent({explain = false} = {}) {
@@ -114,9 +127,15 @@ export async function deprecateCurrent({explain = false} = {}) {
     return cursor.explain('executionStats');
   }
 
-  const result = await collection.updateOne(query, {$set, $unset});
-  // return `true` if a tokenizer was marked as `deprecated`
-  return result.result.n === 0;
+  try {
+    const result = await collection.updateOne(
+      query, {$set, $unset}, database.writeOptions);
+    // return `true` if a tokenizer was marked as `deprecated`
+    return result.result.n === 0;
+  } catch(cause) {
+    throw new BedrockError('Error deprecating current tokenizer.',
+      'DatabaseError', null, cause);
+  }
 }
 
 /**
@@ -141,6 +160,11 @@ function _isRotationCheckRequired() {
   return Math.random() <= 0.2;
 }
 
+/**
+ * Returns the current tokenizer object.
+ *
+ * @return {Promise<{hmac: Hmac, id: string}>}
+ */
 async function _getCurrentTokenizer() {
   // 1. Get tokenizer from cache.
   if(CACHED_TOKENIZER) {

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -307,7 +307,7 @@ export async function _createTokenizer() {
     await _markTokenizerAsCurrent();
   } catch(cause) {
     const error = new BedrockError(
-      'Error creating keystore for tokenizer.', 'UnknownError',
+      'Error creating keystore for tokenizer.', 'OperationError',
       {httpStatusCode: 500, public: true}, cause);
     logger.error(error);
     throw error;

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -102,7 +102,8 @@ export async function getCurrent() {
   try {
     tokenizer = await _getCurrentTokenizer();
   } catch(cause) {
-    throw new BedrockError('Could not get current tokenizer.', 'NotFoundError',
+    throw new BedrockError(
+      'Could not get current tokenizer.', 'NotFoundError',
       {httpStatusCode: 404}, cause);
   }
   return tokenizer;
@@ -133,8 +134,9 @@ export async function deprecateCurrent({explain = false} = {}) {
     // return `true` if a tokenizer was marked as `deprecated`
     return result.result.n === 0;
   } catch(cause) {
-    throw new BedrockError('Error deprecating current tokenizer.',
-      'DatabaseError', null, cause);
+    throw new BedrockError(
+      'Error deprecating current tokenizer.',
+      'InvalidStateError', null, cause);
   }
 }
 

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -90,12 +90,6 @@ export async function getCurrent() {
       const shouldRotate = await AUTO_ROTATION_CHECKER();
       if(shouldRotate) {
         await deprecateCurrent();
-        // clear cached current tokenizer; note: the cached value *may* not
-        // match the one that was just marked deprecated due to multiple
-        // concurrent requests modifying the cached value, but this should
-        // not create invalid state, rather, it just generates an extra
-        // database read
-        CACHED_TOKENIZER = null;
       }
     }
 
@@ -138,6 +132,13 @@ export async function deprecateCurrent({explain = false} = {}) {
     throw new BedrockError(
       'Error deprecating current tokenizer.',
       'OperationError', null, cause);
+  } finally {
+    // clear cached current tokenizer; note: the cached value *may* not
+    // match the one that was just marked deprecated due to multiple
+    // concurrent requests modifying the cached value, but this should
+    // not create invalid state, rather, it just generates an extra
+    // database read
+    CACHED_TOKENIZER = null;
   }
 }
 

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -79,7 +79,8 @@ export async function get({id, explain = false} = {}) {
  * Returns the current tokenizer object (rotating it if required).
  *
  * @typedef Hmac
- * @return {Promise<{hmac: Hmac, id: string}>}
+ *
+ * @returns {Promise<{hmac: Hmac, id: string}>} The current tokenizer.
  */
 export async function getCurrent() {
   try {
@@ -102,9 +103,10 @@ export async function getCurrent() {
     return await _getCurrentTokenizer();
   } catch(cause) {
     const error = new BedrockError(
-      'Could not get current tokenizer.', 'InvalidStateError',
-      {httpStatusCode: 503}, cause);
-    logger.error(error);
+      'Could not get current tokenizer.',
+      'OperationError',
+      {httpStatusCode: 500}, cause);
+    logger.error(error.message, {error});
     throw error;
   }
 }
@@ -136,7 +138,7 @@ export async function deprecateCurrent({explain = false} = {}) {
   } catch(cause) {
     throw new BedrockError(
       'Error deprecating current tokenizer.',
-      'InvalidStateError', null, cause);
+      'OperationError', null, cause);
   }
 }
 
@@ -165,7 +167,7 @@ function _isRotationCheckRequired() {
 /**
  * Returns the current tokenizer object.
  *
- * @return {Promise<{hmac: Hmac, id: string}>}
+ * @returns {Promise<{hmac: Hmac, id: string}>} The current tokenizer.
  */
 async function _getCurrentTokenizer() {
   // 1. Get tokenizer from cache.
@@ -229,7 +231,7 @@ export async function _readCurrentTokenizerRecord({explain = false} = {}) {
     const error = new BedrockError(
       'Current tokenizer not found.',
       'NotFoundError', {httpStatusCode: 404, public: true});
-    logger.error(error);
+    logger.error(error.message, {error});
     throw error;
   }
   return record;
@@ -309,7 +311,7 @@ export async function _createTokenizer() {
     const error = new BedrockError(
       'Error creating keystore for tokenizer.', 'OperationError',
       {httpStatusCode: 500, public: true}, cause);
-    logger.error(error);
+    logger.error(error.message, {error});
     throw error;
   }
 }
@@ -341,15 +343,14 @@ export async function _readyTokenizer({
 
   const result = await collection.updateOne(query, {$set});
   if(result.result.n === 0) {
-    const details = {
-      tokenizer: tokenizer.id,
-      httpStatusCode: 409,
-      public: true
-    };
     throw new BedrockError(
       'Could not update tokenizer; ' +
       'tokenizer either not found or in an unexpected state.',
-      'InvalidStateError', details);
+      'InvalidStateError', {
+        tokenizer: tokenizer.id,
+        httpStatusCode: 409,
+        public: true
+      });
   }
 }
 

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -292,9 +292,19 @@ export async function _createTokenizer() {
   }
 
   // 4. Create a keystore and HMAC key for the tokenizer.
-  const keystore = await kms.createKeystore({
-    controller: capabilityAgent.id, referenceId: 'primary'
-  });
+  let keystore;
+  try {
+    keystore = await kms.createKeystore({
+      controller: capabilityAgent.id, referenceId: 'primary'
+    });
+  } catch(cause) {
+    const error = new BedrockError(
+      'Error creating keystore for tokenizer.', 'UnknownError',
+      {httpStatusCode: 500, public: true}, cause);
+    logger.error(error);
+    throw error;
+  }
+
   const keystoreAgent = kms.getKeystoreAgent(
     {capabilityAgent, keystoreId: keystore.id});
   const key = await keystoreAgent.generateKey({type: 'hmac'});

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -6,6 +6,7 @@ import * as database from '@bedrock/mongodb';
 import * as kms from './kms.js';
 import {adaptHmac} from './hmacAdapter.js';
 import {createRequire} from 'module';
+import {logger} from './logger.js';
 import {promisify} from 'util';
 import {randomBytes} from 'crypto';
 const require = createRequire(import.meta.url);
@@ -64,13 +65,11 @@ export async function get({id, explain = false} = {}) {
 
   const record = await collection.findOne(query, {projection});
   if(!record) {
-    const details = {
-      httpStatusCode: 404,
-      public: true
-    };
-    throw new BedrockError(
+    const error = new BedrockError(
       'Tokenizer not found.',
-      'NotFoundError', details);
+      'InvalidStateError', {httpStatusCode: 503, public: true});
+    logger.error(error);
+    throw error;
   }
 
   return _tokenizerFromRecord({record});
@@ -102,9 +101,11 @@ export async function getCurrent() {
   try {
     tokenizer = await _getCurrentTokenizer();
   } catch(cause) {
-    throw new BedrockError(
-      'Could not get current tokenizer.', 'NotFoundError',
-      {httpStatusCode: 404}, cause);
+    const error = new BedrockError(
+      'Could not get current tokenizer.', 'InvalidStateError',
+      {httpStatusCode: 503}, cause);
+    logger.error(error);
+    throw error;
   }
   return tokenizer;
 }
@@ -226,13 +227,11 @@ export async function _readCurrentTokenizerRecord({explain = false} = {}) {
 
   const record = await collection.findOne(query, {projection});
   if(!record) {
-    const details = {
-      httpStatusCode: 404,
-      public: true
-    };
-    throw new BedrockError(
+    const error = new BedrockError(
       'Current tokenizer not found.',
-      'NotFoundError', details);
+      'InvalidStateError', {httpStatusCode: 503, public: true});
+    logger.error(error);
+    throw error;
   }
   return record;
 }


### PR DESCRIPTION
Depends on https://github.com/digitalbazaar/http-client/pull/12 and https://github.com/digitalbazaar/webkms-client/pull/32.

* Also throw error if `bedrock.config.tokenizer.kms.baseUrl` is not configured.