### PR TITLE
Add database tests to explain performance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # bedrock-tokenizer ChangeLog
 
+## 2.2.0 - TBD
+
+### Added
+- Added optional `explain` param to get more details about database performance.
+- Added database tests in order to check database performance.
+
+### Changed
+- Exposed helper functions in order to properly test database calls.
+
 ## 2.1.0 - 2021-09-20
 
 ### Changed

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -17,6 +17,10 @@ let AUTO_ROTATION_CHECKER = null;
 bedrock.events.on('bedrock-mongodb.ready', async () => {
   await database.openCollections(['tokenizer-tokenizer']);
 
+  // the created indexes of 'tokenizer.id', 'tokenizer.state' and
+  // 'tokenizer.current' ensure that all queries are indexed properly. No
+  // additional indexes should be created here unless additional queries need
+  // to be added.
   await database.createIndexes([{
     collection: 'tokenizer-tokenizer',
     fields: {'tokenizer.id': 1},
@@ -42,12 +46,19 @@ export async function get({id, explain = false} = {}) {
     throw new TypeError('"id" must be a string.');
   }
 
+  // the query of 'tokenizer.id' is properly indexed. No additional queries
+  // should be added here without ensuring that additional queries are properly
+  // indexed first.
   const query = {'tokenizer.id': id};
   const projection = {_id: 0};
   const collection = database.collections['tokenizer-tokenizer'];
 
   if(explain) {
-    const cursor = await collection.find(query, projection);
+    // this is used to explain the results of the query in order to ensure that
+    // the query is using the proper indexes. 'find().limit(1)' is used here
+    // since 'find()' returns a cursor method which allows the use of the
+    // explain function.
+    const cursor = await collection.find(query, projection).limit(1);
     return cursor.explain('executionStats');
   }
 
@@ -86,6 +97,10 @@ export async function getCurrent() {
 
 export async function deprecateCurrent() {
   // mark the `current` tokenizer as deprecated
+
+  // the query of 'tokenizer.state' is properly indexed. No additional queries
+  // should be added here without ensuring that additional queries are properly
+  // indexed first.
   const query = {
     'tokenizer.state': 'current'
   };
@@ -172,12 +187,19 @@ async function _getCurrentTokenizer() {
 }
 
 export async function _readCurrentTokenizerRecord({explain = false} = {}) {
+  // the query of 'tokenizer.current' is properly indexed. No additional queries
+  // should be added here without ensuring that additional queries are properly
+  // indexed first.
   const query = {'tokenizer.current': true};
   const projection = {_id: 0};
   const collection = database.collections['tokenizer-tokenizer'];
 
   if(explain) {
-    const cursor = await collection.find(query, projection);
+    // this is used to explain the results of the query in order to ensure that
+    // the query is using the proper indexes. 'find().limit(1)' is used here
+    // since 'find()' returns a cursor method which allows the use of the
+    // explain function.
+    const cursor = await collection.find(query, projection).limit(1);
     return cursor.explain('executionStats');
   }
 
@@ -212,7 +234,7 @@ async function _tokenizerFromRecord({record}) {
   return {id: tokenizer.id, hmac};
 }
 
-export async function _createTokenizer({explain = false} = {}) {
+export async function _createTokenizer() {
   // 1. Generate a random secret.
   const secret = await randomBytesAsync(32);
   // 2. Generate capability agent from handle and secret.
@@ -233,9 +255,6 @@ export async function _createTokenizer({explain = false} = {}) {
   };
   try {
     const result = await collection.insertOne(record, database.writeOptions);
-    if(explain) {
-      return result;
-    }
     record = result.ops[0];
   } catch(e) {
     if(!database.isDuplicateError(e)) {
@@ -267,6 +286,9 @@ export async function _createTokenizer({explain = false} = {}) {
 export async function _addKeystoreAndHmacKeys({
   tokenizer, keystore, key, explain = false
 } = {}) {
+  // the compound query of 'tokenizer.id' and 'tokenizer.state' is properly
+  // indexed. No additional queries should be added here without ensuring that
+  // additional queries are properly indexed first.
   const query = {
     'tokenizer.id': tokenizer.id,
     'tokenizer.state': 'pending'
@@ -283,15 +305,12 @@ export async function _addKeystoreAndHmacKeys({
   const collection = database.collections['tokenizer-tokenizer'];
 
   if(explain) {
-    const resultMap = new Map();
-    const cursor = await collection.find(query);
-    resultMap.set('queryCursor', await cursor.explain('executionStats'));
-
-    const result = await collection.updateOne(
-      query, {$set}, database.writeOptions);
-    resultMap.set('updateResult', result);
-
-    return resultMap;
+    // this is used to explain the results of the query in order to ensure that
+    // the query is using the proper indexes. 'find().limit(1)' is used here
+    // since 'find()' returns a cursor method which allows the use of the
+    // explain function.
+    const cursor = await collection.find(query).limit(1);
+    return cursor.explain('executionStats');
   }
 
   const result = await collection.updateOne(
@@ -311,6 +330,10 @@ export async function _addKeystoreAndHmacKeys({
 
 export async function _markTokenizerAsCurrent({explain = false} = {}) {
   // mark any `ready` tokenizer as current
+
+  // the query of 'tokenizer.state' is properly indexed. No additional queries
+  // should be added here without ensuring that additional queries are properly
+  // indexed first.
   const query = {
     'tokenizer.state': 'ready'
   };
@@ -322,15 +345,12 @@ export async function _markTokenizerAsCurrent({explain = false} = {}) {
   const collection = database.collections['tokenizer-tokenizer'];
 
   if(explain) {
-    const resultMap = new Map();
-    const cursor = await collection.find(query);
-    resultMap.set('queryCursor', await cursor.explain('executionStats'));
-
-    const result = await collection.updateOne(
-      query, {$set}, database.writeOptions);
-    resultMap.set('updateResult', result);
-
-    return resultMap;
+    // this is used to explain the results of the query in order to ensure that
+    // the query is using the proper indexes. 'find().limit(1)' is used here
+    // since 'find()' returns a cursor method which allows the use of the
+    // explain function.
+    const cursor = await collection.find(query).limit(1);
+    return cursor.explain('executionStats');
   }
 
   try {

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -46,6 +46,11 @@ export async function get({id, explain = false} = {}) {
     throw new TypeError('"id" must be a string.');
   }
 
+  // return cached tokenizer if available
+  if(!explain && CACHED_TOKENIZER && CACHED_TOKENIZER.id === id) {
+    return CACHED_TOKENIZER;
+  }
+
   // the query of 'tokenizer.id' is properly indexed. No additional queries
   // should be added here without ensuring that additional queries are properly
   // indexed first.
@@ -60,11 +65,6 @@ export async function get({id, explain = false} = {}) {
     // explain function.
     const cursor = await collection.find(query, projection).limit(1);
     return cursor.explain('executionStats');
-  }
-
-  // return cached tokenizer if available
-  if(CACHED_TOKENIZER && CACHED_TOKENIZER.id === id) {
-    return CACHED_TOKENIZER;
   }
 
   const record = await collection.findOne(query, projection);

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -37,9 +37,19 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
   }]);
 });
 
-export async function get({id} = {}) {
+export async function get({id, explain = false} = {}) {
   if(!(id && typeof id === 'string')) {
     throw new TypeError('"id" must be a string.');
+  }
+
+  const query = {'tokenizer.id': id};
+  const projection = {_id: 0};
+  const collection = database.collections['tokenizer-tokenizer'];
+
+  if(explain) {
+    const cursor = await collection.find(query, projection);
+    await cursor.rewind();
+    return cursor.explain('executionStats');
   }
 
   // return cached tokenizer if available
@@ -47,9 +57,6 @@ export async function get({id} = {}) {
     return CACHED_TOKENIZER;
   }
 
-  const query = {'tokenizer.id': id};
-  const projection = {_id: 0};
-  const collection = database.collections['tokenizer-tokenizer'];
   const record = await collection.findOne(query, projection);
   if(!record) {
     const details = {
@@ -165,10 +172,16 @@ async function _getCurrentTokenizer() {
   return tokenizer;
 }
 
-async function _readCurrentTokenizerRecord() {
+export async function _readCurrentTokenizerRecord({explain = false} = {}) {
   const query = {'tokenizer.current': true};
   const projection = {_id: 0};
   const collection = database.collections['tokenizer-tokenizer'];
+
+  if(explain) {
+    const cursor = await collection.find(query, projection);
+    return cursor.explain('executionStats');
+  }
+
   const record = await collection.findOne(query, projection);
   if(!record) {
     const details = {
@@ -200,7 +213,7 @@ async function _tokenizerFromRecord({record}) {
   return {id: tokenizer.id, hmac};
 }
 
-async function _createTokenizer() {
+export async function _createTokenizer({explain = false} = {}) {
   // 1. Generate a random secret.
   const secret = await randomBytesAsync(32);
   // 2. Generate capability agent from handle and secret.
@@ -221,6 +234,9 @@ async function _createTokenizer() {
   };
   try {
     const result = await collection.insertOne(record, database.writeOptions);
+    if(explain) {
+      return result;
+    }
     record = result.ops[0];
   } catch(e) {
     if(!database.isDuplicateError(e)) {
@@ -243,6 +259,15 @@ async function _createTokenizer() {
   const key = await keystoreAgent.generateKey({type: 'hmac'});
 
   // 5. Add keystore and HMAC info to the tokenizer record.
+  await _addKeystoreAndHmacKeys({tokenizer, keystore, key});
+
+  // mark a tokenizer as current
+  await _markTokenizerAsCurrent();
+}
+
+export async function _addKeystoreAndHmacKeys({
+  tokenizer, keystore, key, explain = false
+} = {}) {
   const query = {
     'tokenizer.id': tokenizer.id,
     'tokenizer.state': 'pending'
@@ -256,6 +281,20 @@ async function _createTokenizer() {
       type: key.type
     }
   };
+  const collection = database.collections['tokenizer-tokenizer'];
+
+  if(explain) {
+    const resultMap = new Map();
+    const cursor = await collection.find(query);
+    resultMap.set('queryCursor', await cursor.explain('executionStats'));
+
+    const result = await collection.updateOne(
+      query, {$set}, database.writeOptions);
+    resultMap.set('updateResult', result);
+
+    return resultMap;
+  }
+
   const result = await collection.updateOne(
     query, {$set}, database.writeOptions);
   if(result.result.n === 0) {
@@ -269,12 +308,9 @@ async function _createTokenizer() {
       'tokenizer either not found or in an unexpected state.',
       'InvalidStateError', details);
   }
-
-  // mark a tokenizer as current
-  await _markTokenizerAsCurrent();
 }
 
-async function _markTokenizerAsCurrent() {
+export async function _markTokenizerAsCurrent({explain = false} = {}) {
   // mark any `ready` tokenizer as current
   const query = {
     'tokenizer.state': 'ready'
@@ -285,6 +321,19 @@ async function _markTokenizerAsCurrent() {
     'tokenizer.current': true
   };
   const collection = database.collections['tokenizer-tokenizer'];
+
+  if(explain) {
+    const resultMap = new Map();
+    const cursor = await collection.find(query);
+    resultMap.set('queryCursor', await cursor.explain('executionStats'));
+
+    const result = await collection.updateOne(
+      query, {$set}, database.writeOptions);
+    resultMap.set('updateResult', result);
+
+    return resultMap;
+  }
+
   try {
     const result = await collection.updateOne(
       query, {$set}, database.writeOptions);

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -48,7 +48,6 @@ export async function get({id, explain = false} = {}) {
 
   if(explain) {
     const cursor = await collection.find(query, projection);
-    await cursor.rewind();
     return cursor.explain('executionStats');
   }
 

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -63,11 +63,11 @@ export async function get({id, explain = false} = {}) {
     // the query is using the proper indexes. 'find().limit(1)' is used here
     // since 'find()' returns a cursor method which allows the use of the
     // explain function.
-    const cursor = await collection.find(query, projection).limit(1);
+    const cursor = await collection.find(query, {projection}).limit(1);
     return cursor.explain('executionStats');
   }
 
-  const record = await collection.findOne(query, projection);
+  const record = await collection.findOne(query, {projection});
   if(!record) {
     const details = {
       httpStatusCode: 404,
@@ -199,11 +199,11 @@ export async function _readCurrentTokenizerRecord({explain = false} = {}) {
     // the query is using the proper indexes. 'find().limit(1)' is used here
     // since 'find()' returns a cursor method which allows the use of the
     // explain function.
-    const cursor = await collection.find(query, projection).limit(1);
+    const cursor = await collection.find(query, {projection}).limit(1);
     return cursor.explain('executionStats');
   }
 
-  const record = await collection.findOne(query, projection);
+  const record = await collection.findOne(query, {projection});
   if(!record) {
     const details = {
       httpStatusCode: 404,

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -52,8 +52,8 @@ export async function get({id, explain = false} = {}) {
   const collection = database.collections['tokenizer-tokenizer'];
 
   if(explain) {
-    // 'find().limit(1)' is used here since 'find()' returns a cursor method
-    // which allows the use of the explain function.
+    // 'find().limit(1)' is used here because 'findOne()' doesn't return a
+    // cursor method which allows the use of the explain function.
     const cursor = await collection.find(query, {projection}).limit(1);
     return cursor.explain('executionStats');
   }
@@ -99,8 +99,8 @@ export async function deprecateCurrent({explain = false} = {}) {
   const collection = database.collections['tokenizer-tokenizer'];
 
   if(explain) {
-    // 'find().limit(1)' is used here since 'find()' returns a cursor method
-    // which allows the use of the explain function.
+    // 'find().limit(1)' is used here because 'updateOne()' doesn't return a
+    // cursor method which allows the use of the explain function.
     const cursor = await collection.find(query).limit(1);
     return cursor.explain('executionStats');
   }
@@ -187,8 +187,8 @@ export async function _readCurrentTokenizerRecord({explain = false} = {}) {
   const collection = database.collections['tokenizer-tokenizer'];
 
   if(explain) {
-    // 'find().limit(1)' is used here since 'find()' returns a cursor method
-    // which allows the use of the explain function.
+    // 'find().limit(1)' is used here because 'findOne()' doesn't return a
+    // cursor method which allows the use of the explain function.
     const cursor = await collection.find(query, {projection}).limit(1);
     return cursor.explain('executionStats');
   }
@@ -292,8 +292,8 @@ export async function _addKeystoreAndHmacKeys({
   const collection = database.collections['tokenizer-tokenizer'];
 
   if(explain) {
-    // 'find().limit(1)' is used here since 'find()' returns a cursor method
-    // which allows the use of the explain function.
+    // 'find().limit(1)' is used here because 'updateOne()' doesn't return a
+    // cursor method which allows the use of the explain function.
     const cursor = await collection.find(query).limit(1);
     return cursor.explain('executionStats');
   }
@@ -326,8 +326,8 @@ export async function _markTokenizerAsCurrent({explain = false} = {}) {
   const collection = database.collections['tokenizer-tokenizer'];
 
   if(explain) {
-    // 'find().limit(1)' is used here since 'find()' returns a cursor method
-    // which allows the use of the explain function.
+    // 'find().limit(1)' is used here because 'updateOne()' doesn't return a
+    // cursor method which allows the use of the explain function.
     const cursor = await collection.find(query).limit(1);
     return cursor.explain('executionStats');
   }

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -266,14 +266,14 @@ export async function _createTokenizer() {
     {capabilityAgent, keystoreId: keystore.id});
   const key = await keystoreAgent.generateKey({type: 'hmac'});
 
-  // 5. Add keystore and HMAC info to the tokenizer record.
-  await _addKeystoreAndHmacKeys({tokenizer, keystore, key});
+  // 5. Ready tokenizer for use by adding keystore and HMAC key to its record.
+  await _readyTokenizer({tokenizer, keystore, key});
 
-  // mark a tokenizer as current
+  // mark any ready tokenizer as current
   await _markTokenizerAsCurrent();
 }
 
-export async function _addKeystoreAndHmacKeys({
+export async function _readyTokenizer({
   tokenizer, keystore, key, explain = false
 } = {}) {
   const query = {

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -17,10 +17,6 @@ let AUTO_ROTATION_CHECKER = null;
 bedrock.events.on('bedrock-mongodb.ready', async () => {
   await database.openCollections(['tokenizer-tokenizer']);
 
-  // the created indexes of 'tokenizer.id', 'tokenizer.state' and
-  // 'tokenizer.current' ensure that all queries are indexed properly. No
-  // additional indexes should be created here unless additional queries need
-  // to be added.
   await database.createIndexes([{
     collection: 'tokenizer-tokenizer',
     fields: {'tokenizer.id': 1},
@@ -51,18 +47,13 @@ export async function get({id, explain = false} = {}) {
     return CACHED_TOKENIZER;
   }
 
-  // the query of 'tokenizer.id' is properly indexed. No additional queries
-  // should be added here without ensuring that additional queries are properly
-  // indexed first.
   const query = {'tokenizer.id': id};
   const projection = {_id: 0};
   const collection = database.collections['tokenizer-tokenizer'];
 
   if(explain) {
-    // this is used to explain the results of the query in order to ensure that
-    // the query is using the proper indexes. 'find().limit(1)' is used here
-    // since 'find()' returns a cursor method which allows the use of the
-    // explain function.
+    // 'find().limit(1)' is used here since 'find()' returns a cursor method
+    // which allows the use of the explain function.
     const cursor = await collection.find(query, {projection}).limit(1);
     return cursor.explain('executionStats');
   }
@@ -95,12 +86,8 @@ export async function getCurrent() {
   return _getCurrentTokenizer();
 }
 
-export async function deprecateCurrent() {
+export async function deprecateCurrent({explain = false} = {}) {
   // mark the `current` tokenizer as deprecated
-
-  // the query of 'tokenizer.state' is properly indexed. No additional queries
-  // should be added here without ensuring that additional queries are properly
-  // indexed first.
   const query = {
     'tokenizer.state': 'current'
   };
@@ -110,6 +97,14 @@ export async function deprecateCurrent() {
   };
   const $unset = {'tokenizer.current': ''};
   const collection = database.collections['tokenizer-tokenizer'];
+
+  if(explain) {
+    // 'find().limit(1)' is used here since 'find()' returns a cursor method
+    // which allows the use of the explain function.
+    const cursor = await collection.find(query).limit(1);
+    return cursor.explain('executionStats');
+  }
+
   try {
     const result = await collection.updateOne(
       query, {$set, $unset}, database.writeOptions);
@@ -187,18 +182,13 @@ async function _getCurrentTokenizer() {
 }
 
 export async function _readCurrentTokenizerRecord({explain = false} = {}) {
-  // the query of 'tokenizer.current' is properly indexed. No additional queries
-  // should be added here without ensuring that additional queries are properly
-  // indexed first.
   const query = {'tokenizer.current': true};
   const projection = {_id: 0};
   const collection = database.collections['tokenizer-tokenizer'];
 
   if(explain) {
-    // this is used to explain the results of the query in order to ensure that
-    // the query is using the proper indexes. 'find().limit(1)' is used here
-    // since 'find()' returns a cursor method which allows the use of the
-    // explain function.
+    // 'find().limit(1)' is used here since 'find()' returns a cursor method
+    // which allows the use of the explain function.
     const cursor = await collection.find(query, {projection}).limit(1);
     return cursor.explain('executionStats');
   }
@@ -286,9 +276,6 @@ export async function _createTokenizer() {
 export async function _addKeystoreAndHmacKeys({
   tokenizer, keystore, key, explain = false
 } = {}) {
-  // the compound query of 'tokenizer.id' and 'tokenizer.state' is properly
-  // indexed. No additional queries should be added here without ensuring that
-  // additional queries are properly indexed first.
   const query = {
     'tokenizer.id': tokenizer.id,
     'tokenizer.state': 'pending'
@@ -305,10 +292,8 @@ export async function _addKeystoreAndHmacKeys({
   const collection = database.collections['tokenizer-tokenizer'];
 
   if(explain) {
-    // this is used to explain the results of the query in order to ensure that
-    // the query is using the proper indexes. 'find().limit(1)' is used here
-    // since 'find()' returns a cursor method which allows the use of the
-    // explain function.
+    // 'find().limit(1)' is used here since 'find()' returns a cursor method
+    // which allows the use of the explain function.
     const cursor = await collection.find(query).limit(1);
     return cursor.explain('executionStats');
   }
@@ -330,10 +315,6 @@ export async function _addKeystoreAndHmacKeys({
 
 export async function _markTokenizerAsCurrent({explain = false} = {}) {
   // mark any `ready` tokenizer as current
-
-  // the query of 'tokenizer.state' is properly indexed. No additional queries
-  // should be added here without ensuring that additional queries are properly
-  // indexed first.
   const query = {
     'tokenizer.state': 'ready'
   };
@@ -345,10 +326,8 @@ export async function _markTokenizerAsCurrent({explain = false} = {}) {
   const collection = database.collections['tokenizer-tokenizer'];
 
   if(explain) {
-    // this is used to explain the results of the query in order to ensure that
-    // the query is using the proper indexes. 'find().limit(1)' is used here
-    // since 'find()' returns a cursor method which allows the use of the
-    // explain function.
+    // 'find().limit(1)' is used here since 'find()' returns a cursor method
+    // which allows the use of the explain function.
     const cursor = await collection.find(query).limit(1);
     return cursor.explain('executionStats');
   }

--- a/lib/tokenizers.js
+++ b/lib/tokenizers.js
@@ -53,7 +53,7 @@ export async function get({id, explain = false} = {}) {
 
   if(explain) {
     // 'find().limit(1)' is used here because 'findOne()' doesn't return a
-    // cursor method which allows the use of the explain function.
+    // cursor which allows the use of the explain function.
     const cursor = await collection.find(query, {projection}).limit(1);
     return cursor.explain('executionStats');
   }
@@ -188,7 +188,7 @@ export async function _readCurrentTokenizerRecord({explain = false} = {}) {
 
   if(explain) {
     // 'find().limit(1)' is used here because 'findOne()' doesn't return a
-    // cursor method which allows the use of the explain function.
+    // cursor which allows the use of the explain function.
     const cursor = await collection.find(query, {projection}).limit(1);
     return cursor.explain('executionStats');
   }
@@ -293,7 +293,7 @@ export async function _addKeystoreAndHmacKeys({
 
   if(explain) {
     // 'find().limit(1)' is used here because 'updateOne()' doesn't return a
-    // cursor method which allows the use of the explain function.
+    // cursor which allows the use of the explain function.
     const cursor = await collection.find(query).limit(1);
     return cursor.explain('executionStats');
   }
@@ -327,7 +327,7 @@ export async function _markTokenizerAsCurrent({explain = false} = {}) {
 
   if(explain) {
     // 'find().limit(1)' is used here because 'updateOne()' doesn't return a
-    // cursor method which allows the use of the explain function.
+    // cursor which allows the use of the explain function.
     const cursor = await collection.find(query).limit(1);
     return cursor.explain('executionStats');
   }

--- a/test/mocha/20-database.js
+++ b/test/mocha/20-database.js
@@ -7,8 +7,8 @@ const {requireUncached, cleanDB, insertRecord} = require('./helpers');
 const {tokenizers} = requireUncached('bedrock-tokenizer');
 const {mockRecord} = require('./mock.data.js');
 
-describe('Tokenizer Database Methods', function() {
-  describe('Find Methods', function() {
+describe('Tokenizer Database Tests', function() {
+  describe('Indexes', function() {
     beforeEach(async () => {
       await cleanDB();
     });
@@ -36,11 +36,6 @@ describe('Tokenizer Database Methods', function() {
       executionStats.executionTimeMillis.should.equal(0);
       executionStats.executionStages.inputStage.inputStage.stage.should
         .equal('IXSCAN');
-    });
-  });
-  describe('Update Methods', function() {
-    beforeEach(async () => {
-      await cleanDB();
     });
     it(`is properly indexed for 'state' parameter`, async function() {
       const record = mockRecord;

--- a/test/mocha/20-database.js
+++ b/test/mocha/20-database.js
@@ -21,7 +21,6 @@ describe('Tokenizer Database Tests', function() {
       executionStats.nReturned.should.equal(1);
       executionStats.totalKeysExamined.should.equal(1);
       executionStats.totalDocsExamined.should.equal(1);
-      executionStats.executionTimeMillis.should.equal(0);
       executionStats.executionStages.inputStage.inputStage.inputStage.stage
         .should.equal('IXSCAN');
     });
@@ -33,7 +32,6 @@ describe('Tokenizer Database Tests', function() {
       executionStats.nReturned.should.equal(1);
       executionStats.totalKeysExamined.should.equal(1);
       executionStats.totalDocsExamined.should.equal(1);
-      executionStats.executionTimeMillis.should.equal(0);
       executionStats.executionStages.inputStage.inputStage.inputStage.stage
         .should.equal('IXSCAN');
     });
@@ -48,7 +46,6 @@ describe('Tokenizer Database Tests', function() {
       executionStats.nReturned.should.equal(1);
       executionStats.totalKeysExamined.should.equal(1);
       executionStats.totalDocsExamined.should.equal(1);
-      executionStats.executionTimeMillis.should.equal(0);
       executionStats.executionStages.inputStage.inputStage.stage.should
         .equal('IXSCAN');
     });
@@ -72,7 +69,6 @@ describe('Tokenizer Database Tests', function() {
         executionStats.nReturned.should.equal(1);
         executionStats.totalKeysExamined.should.equal(1);
         executionStats.totalDocsExamined.should.equal(1);
-        executionStats.executionTimeMillis.should.equal(0);
         executionStats.executionStages.inputStage.inputStage.stage.should
           .equal('IXSCAN');
       });

--- a/test/mocha/20-database.js
+++ b/test/mocha/20-database.js
@@ -22,8 +22,8 @@ describe('Tokenizer Database Tests', function() {
       executionStats.totalKeysExamined.should.equal(1);
       executionStats.totalDocsExamined.should.equal(1);
       executionStats.executionTimeMillis.should.equal(0);
-      executionStats.executionStages.inputStage.inputStage.stage.should
-        .equal('IXSCAN');
+      executionStats.executionStages.inputStage.inputStage.inputStage.stage
+        .should.equal('IXSCAN');
     });
     it(`is properly indexed for 'current' parameter`, async function() {
       await tokenizers._createTokenizer();
@@ -34,8 +34,8 @@ describe('Tokenizer Database Tests', function() {
       executionStats.totalKeysExamined.should.equal(1);
       executionStats.totalDocsExamined.should.equal(1);
       executionStats.executionTimeMillis.should.equal(0);
-      executionStats.executionStages.inputStage.inputStage.stage.should
-        .equal('IXSCAN');
+      executionStats.executionStages.inputStage.inputStage.inputStage.stage
+        .should.equal('IXSCAN');
     });
     it(`is properly indexed for 'state' parameter`, async function() {
       const record = mockRecord;

--- a/test/mocha/20-database.js
+++ b/test/mocha/20-database.js
@@ -37,29 +37,6 @@ describe('Tokenizer Database Methods', function() {
       executionStats.executionStages.inputStage.inputStage.stage.should
         .equal('IXSCAN');
     });
-    it(`No documents are returned when 'id' parameter is not found`,
-      async function() {
-        const id = '1234';
-        const {executionStats} = await tokenizers.get({id, explain: true});
-        executionStats.nReturned.should.equal(0);
-        executionStats.totalKeysExamined.should.equal(0);
-        executionStats.totalDocsExamined.should.equal(0);
-        executionStats.executionTimeMillis.should.equal(0);
-        executionStats.executionStages.inputStage.inputStage.stage.should
-          .equal('IXSCAN');
-      });
-    it(`No documents are returned when 'current' parameter is not found`,
-      async function() {
-        const {executionStats} = await tokenizers._readCurrentTokenizerRecord({
-          explain: true
-        });
-        executionStats.nReturned.should.equal(0);
-        executionStats.totalKeysExamined.should.equal(0);
-        executionStats.totalDocsExamined.should.equal(0);
-        executionStats.executionTimeMillis.should.equal(0);
-        executionStats.executionStages.inputStage.inputStage.stage.should
-          .equal('IXSCAN');
-      });
   });
   describe('Update Methods', function() {
     beforeEach(async () => {
@@ -100,22 +77,6 @@ describe('Tokenizer Database Methods', function() {
         executionStats.nReturned.should.equal(1);
         executionStats.totalKeysExamined.should.equal(1);
         executionStats.totalDocsExamined.should.equal(1);
-        executionStats.executionTimeMillis.should.equal(0);
-        executionStats.executionStages.inputStage.inputStage.stage.should
-          .equal('IXSCAN');
-      });
-    it(`No documents are returned when 'state' parameter is not found`,
-      async function() {
-        const record = mockRecord;
-        record.tokenizer.state = 'notfound';
-        await insertRecord({record});
-
-        const {executionStats} = await tokenizers._markTokenizerAsCurrent({
-          explain: true
-        });
-        executionStats.nReturned.should.equal(0);
-        executionStats.totalKeysExamined.should.equal(0);
-        executionStats.totalDocsExamined.should.equal(0);
         executionStats.executionTimeMillis.should.equal(0);
         executionStats.executionStages.inputStage.inputStage.stage.should
           .equal('IXSCAN');

--- a/test/mocha/20-database.js
+++ b/test/mocha/20-database.js
@@ -8,26 +8,6 @@ const {tokenizers} = requireUncached('bedrock-tokenizer');
 const {mockRecord} = require('./mock.data.js');
 
 describe('Tokenizer Database Methods', function() {
-  describe('Insert Methods', function() {
-    beforeEach(async () => {
-      await cleanDB();
-    });
-    it('it properly inserts a document into database', async function() {
-      let result;
-      let err;
-      try {
-        result = await tokenizers._createTokenizer({explain: true});
-      } catch(e) {
-        console.error(e);
-        err = e;
-      }
-      should.not.exist(err);
-      should.exist(result);
-      result.insertedCount.should.equal(1);
-      result.ops[0].should.have.keys(['meta', 'tokenizer']);
-      result.ops[0].tokenizer.should.have.keys(['id', 'secret', 'state']);
-    });
-  });
   describe('Find Methods', function() {
     beforeEach(async () => {
       await cleanDB();
@@ -42,7 +22,8 @@ describe('Tokenizer Database Methods', function() {
       executionStats.totalKeysExamined.should.equal(1);
       executionStats.totalDocsExamined.should.equal(1);
       executionStats.executionTimeMillis.should.equal(0);
-      executionStats.executionStages.inputStage.stage.should.equal('IXSCAN');
+      executionStats.executionStages.inputStage.inputStage.stage.should
+        .equal('IXSCAN');
     });
     it(`is properly indexed for 'current' parameter`, async function() {
       await tokenizers._createTokenizer();
@@ -53,7 +34,8 @@ describe('Tokenizer Database Methods', function() {
       executionStats.totalKeysExamined.should.equal(1);
       executionStats.totalDocsExamined.should.equal(1);
       executionStats.executionTimeMillis.should.equal(0);
-      executionStats.executionStages.inputStage.stage.should.equal('IXSCAN');
+      executionStats.executionStages.inputStage.inputStage.stage.should
+        .equal('IXSCAN');
     });
     it(`No documents are returned when 'id' parameter is not found`,
       async function() {
@@ -63,7 +45,8 @@ describe('Tokenizer Database Methods', function() {
         executionStats.totalKeysExamined.should.equal(0);
         executionStats.totalDocsExamined.should.equal(0);
         executionStats.executionTimeMillis.should.equal(0);
-        executionStats.executionStages.inputStage.stage.should.equal('IXSCAN');
+        executionStats.executionStages.inputStage.inputStage.stage.should
+          .equal('IXSCAN');
       });
     it(`No documents are returned when 'current' parameter is not found`,
       async function() {
@@ -74,7 +57,8 @@ describe('Tokenizer Database Methods', function() {
         executionStats.totalKeysExamined.should.equal(0);
         executionStats.totalDocsExamined.should.equal(0);
         executionStats.executionTimeMillis.should.equal(0);
-        executionStats.executionStages.inputStage.stage.should.equal('IXSCAN');
+        executionStats.executionStages.inputStage.inputStage.stage.should
+          .equal('IXSCAN');
       });
   });
   describe('Update Methods', function() {
@@ -86,17 +70,15 @@ describe('Tokenizer Database Methods', function() {
       record.tokenizer.state = 'ready';
       await insertRecord({record});
 
-      const map = await tokenizers._markTokenizerAsCurrent({explain: true});
-      const {executionStats} = map.get('queryCursor');
+      const {executionStats} = await tokenizers._markTokenizerAsCurrent({
+        explain: true
+      });
       executionStats.nReturned.should.equal(1);
       executionStats.totalKeysExamined.should.equal(1);
       executionStats.totalDocsExamined.should.equal(1);
       executionStats.executionTimeMillis.should.equal(0);
-      executionStats.executionStages.inputStage.stage.should.equal('IXSCAN');
-
-      const result = map.get('updateResult');
-      result.matchedCount.should.equal(1);
-      result.modifiedCount.should.equal(1);
+      executionStats.executionStages.inputStage.inputStage.stage.should
+        .equal('IXSCAN');
     });
     it(`is properly indexed for compound query of 'id' and 'state'`,
       async function() {
@@ -112,19 +94,15 @@ describe('Tokenizer Database Methods', function() {
           id: '1234',
           type: 'test'
         };
-        const map = await tokenizers._addKeystoreAndHmacKeys({
+        const {executionStats} = await tokenizers._addKeystoreAndHmacKeys({
           tokenizer, keystore, key, explain: true
         });
-        const {executionStats} = map.get('queryCursor');
         executionStats.nReturned.should.equal(1);
         executionStats.totalKeysExamined.should.equal(1);
         executionStats.totalDocsExamined.should.equal(1);
         executionStats.executionTimeMillis.should.equal(0);
-        executionStats.executionStages.inputStage.stage.should.equal('IXSCAN');
-
-        const result = map.get('updateResult');
-        result.matchedCount.should.equal(1);
-        result.modifiedCount.should.equal(1);
+        executionStats.executionStages.inputStage.inputStage.stage.should
+          .equal('IXSCAN');
       });
     it(`No documents are returned when 'state' parameter is not found`,
       async function() {
@@ -132,17 +110,15 @@ describe('Tokenizer Database Methods', function() {
         record.tokenizer.state = 'notfound';
         await insertRecord({record});
 
-        const map = await tokenizers._markTokenizerAsCurrent({explain: true});
-        const {executionStats} = map.get('queryCursor');
+        const {executionStats} = await tokenizers._markTokenizerAsCurrent({
+          explain: true
+        });
         executionStats.nReturned.should.equal(0);
         executionStats.totalKeysExamined.should.equal(0);
         executionStats.totalDocsExamined.should.equal(0);
         executionStats.executionTimeMillis.should.equal(0);
-        executionStats.executionStages.inputStage.stage.should.equal('IXSCAN');
-
-        const result = map.get('updateResult');
-        result.matchedCount.should.equal(0);
-        result.modifiedCount.should.equal(0);
+        executionStats.executionStages.inputStage.inputStage.stage.should
+          .equal('IXSCAN');
       });
   });
 });

--- a/test/mocha/20-database.js
+++ b/test/mocha/20-database.js
@@ -68,7 +68,7 @@ describe('Tokenizer Database Tests', function() {
           .equal('IXSCAN');
       });
     it(`is properly indexed for compound query of 'tokenizer.id' and ` +
-    `'tokenizer.state' in _addKeystoreAndHmacKeys()`, async function() {
+    `'tokenizer.state' in _readyTokenizer()`, async function() {
       const record = mockRecord;
       record.tokenizer.state = 'pending';
       await insertRecord({record});
@@ -81,7 +81,7 @@ describe('Tokenizer Database Tests', function() {
         id: '1234',
         type: 'test'
       };
-      const {executionStats} = await tokenizers._addKeystoreAndHmacKeys({
+      const {executionStats} = await tokenizers._readyTokenizer({
         tokenizer, keystore, key, explain: true
       });
       executionStats.nReturned.should.equal(1);

--- a/test/mocha/20-database.js
+++ b/test/mocha/20-database.js
@@ -1,0 +1,148 @@
+/*!
+ * Copyright (c) 2020-2021 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const {requireUncached, cleanDB, insertRecord} = require('./helpers');
+const {tokenizers} = requireUncached('bedrock-tokenizer');
+const {mockRecord} = require('./mock.data.js');
+
+describe('Tokenizer Database Methods', function() {
+  describe('Insert Methods', function() {
+    beforeEach(async () => {
+      await cleanDB();
+    });
+    it('it properly inserts a document into database', async function() {
+      let result;
+      let err;
+      try {
+        result = await tokenizers._createTokenizer({explain: true});
+      } catch(e) {
+        console.error(e);
+        err = e;
+      }
+      should.not.exist(err);
+      should.exist(result);
+      result.insertedCount.should.equal(1);
+      result.ops[0].should.have.keys(['meta', 'tokenizer']);
+      result.ops[0].tokenizer.should.have.keys(['id', 'secret', 'state']);
+    });
+  });
+  describe('Find Methods', function() {
+    beforeEach(async () => {
+      await cleanDB();
+    });
+    it(`is properly indexed for 'id' parameter`, async function() {
+      const record = mockRecord;
+      await insertRecord({record});
+
+      const {id} = record.tokenizer;
+      const {executionStats} = await tokenizers.get({id, explain: true});
+      executionStats.nReturned.should.equal(1);
+      executionStats.totalKeysExamined.should.equal(1);
+      executionStats.totalDocsExamined.should.equal(1);
+      executionStats.executionTimeMillis.should.equal(0);
+      executionStats.executionStages.inputStage.stage.should.equal('IXSCAN');
+    });
+    it(`is properly indexed for 'current' parameter`, async function() {
+      await tokenizers._createTokenizer();
+      const {executionStats} = await tokenizers._readCurrentTokenizerRecord({
+        explain: true
+      });
+      executionStats.nReturned.should.equal(1);
+      executionStats.totalKeysExamined.should.equal(1);
+      executionStats.totalDocsExamined.should.equal(1);
+      executionStats.executionTimeMillis.should.equal(0);
+      executionStats.executionStages.inputStage.stage.should.equal('IXSCAN');
+    });
+    it(`No documents are returned when 'id' parameter is not found`,
+      async function() {
+        const id = '1234';
+        const {executionStats} = await tokenizers.get({id, explain: true});
+        executionStats.nReturned.should.equal(0);
+        executionStats.totalKeysExamined.should.equal(0);
+        executionStats.totalDocsExamined.should.equal(0);
+        executionStats.executionTimeMillis.should.equal(0);
+        executionStats.executionStages.inputStage.stage.should.equal('IXSCAN');
+      });
+    it(`No documents are returned when 'current' parameter is not found`,
+      async function() {
+        const {executionStats} = await tokenizers._readCurrentTokenizerRecord({
+          explain: true
+        });
+        executionStats.nReturned.should.equal(0);
+        executionStats.totalKeysExamined.should.equal(0);
+        executionStats.totalDocsExamined.should.equal(0);
+        executionStats.executionTimeMillis.should.equal(0);
+        executionStats.executionStages.inputStage.stage.should.equal('IXSCAN');
+      });
+  });
+  describe('Update Methods', function() {
+    beforeEach(async () => {
+      await cleanDB();
+    });
+    it(`is properly indexed for 'state' parameter`, async function() {
+      const record = mockRecord;
+      record.tokenizer.state = 'ready';
+      await insertRecord({record});
+
+      const map = await tokenizers._markTokenizerAsCurrent({explain: true});
+      const {executionStats} = map.get('queryCursor');
+      executionStats.nReturned.should.equal(1);
+      executionStats.totalKeysExamined.should.equal(1);
+      executionStats.totalDocsExamined.should.equal(1);
+      executionStats.executionTimeMillis.should.equal(0);
+      executionStats.executionStages.inputStage.stage.should.equal('IXSCAN');
+
+      const result = map.get('updateResult');
+      result.matchedCount.should.equal(1);
+      result.modifiedCount.should.equal(1);
+    });
+    it(`is properly indexed for compound query of 'id' and 'state'`,
+      async function() {
+        const record = mockRecord;
+        record.tokenizer.state = 'pending';
+        await insertRecord({record});
+
+        const {tokenizer} = record;
+        const keystore = {
+          id: '4321'
+        };
+        const key = {
+          id: '1234',
+          type: 'test'
+        };
+        const map = await tokenizers._addKeystoreAndHmacKeys({
+          tokenizer, keystore, key, explain: true
+        });
+        const {executionStats} = map.get('queryCursor');
+        executionStats.nReturned.should.equal(1);
+        executionStats.totalKeysExamined.should.equal(1);
+        executionStats.totalDocsExamined.should.equal(1);
+        executionStats.executionTimeMillis.should.equal(0);
+        executionStats.executionStages.inputStage.stage.should.equal('IXSCAN');
+
+        const result = map.get('updateResult');
+        result.matchedCount.should.equal(1);
+        result.modifiedCount.should.equal(1);
+      });
+    it(`No documents are returned when 'state' parameter is not found`,
+      async function() {
+        const record = mockRecord;
+        record.tokenizer.state = 'notfound';
+        await insertRecord({record});
+
+        const map = await tokenizers._markTokenizerAsCurrent({explain: true});
+        const {executionStats} = map.get('queryCursor');
+        executionStats.nReturned.should.equal(0);
+        executionStats.totalKeysExamined.should.equal(0);
+        executionStats.totalDocsExamined.should.equal(0);
+        executionStats.executionTimeMillis.should.equal(0);
+        executionStats.executionStages.inputStage.stage.should.equal('IXSCAN');
+
+        const result = map.get('updateResult');
+        result.matchedCount.should.equal(0);
+        result.modifiedCount.should.equal(0);
+      });
+  });
+});

--- a/test/mocha/20-database.js
+++ b/test/mocha/20-database.js
@@ -67,7 +67,7 @@ describe('Tokenizer Database Tests', function() {
         executionStats.executionStages.inputStage.inputStage.stage.should
           .equal('IXSCAN');
       });
-    it(`is properly indexed for compound query of 'tokenizer.id' and` +
+    it(`is properly indexed for compound query of 'tokenizer.id' and ` +
     `'tokenizer.state' in _addKeystoreAndHmacKeys()`, async function() {
       const record = mockRecord;
       record.tokenizer.state = 'pending';

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -31,6 +31,11 @@ exports.cleanDB = async () => {
   await database.collections['tokenizer-tokenizer'].deleteMany({});
 };
 
+exports.insertRecord = async ({record}) => {
+  const collection = database.collections['tokenizer-tokenizer'];
+  await collection.insertOne(record, database.writeOptions);
+};
+
 // we need to reset the module for most tests
 exports.requireUncached = module => {
   delete require.cache[require.resolve(module)];

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const data = {};
-module.exports = data;
 
 // mock product IDs and reverse lookup for webkms/edv/etc service products
 data.productIdMap = new Map();
@@ -25,3 +24,18 @@ for(const product of products) {
   data.productIdMap.set(product.id, product);
   data.productIdMap.set(product.name, product);
 }
+
+const now = Date.now();
+const mockRecord = {
+  meta: {
+    created: now,
+    updated: now
+  },
+  tokenizer: {
+    id: 'did:key:z6MkvyeeUsH7bY61YT8599RYUbytYjPt77k1mN6VT27S7LfM',
+    secret: 'ky8aka7eZd976dy240e2nm_k_kUy-5H0TGDtm2pfqwY',
+    state: 'pending'
+  }
+};
+
+module.exports = {data, mockRecord};


### PR DESCRIPTION
This PR is for adding an optional `explain` param to get more details about database performance. Database tests have been added that check to make sure the correct amount of docs are returned and that an index scan was done for all queries.

I had to expose some helper functions in order to write proper database tests.